### PR TITLE
Close mobile menu function

### DIFF
--- a/src/js/footer/closeMobileMenu/index.js
+++ b/src/js/footer/closeMobileMenu/index.js
@@ -1,0 +1,7 @@
+// This function is needed to close the menu if the page was loaded using the browser back button (from cache)
+window.addEventListener('pageshow', function (event) {
+  // Checking if the page was loaded from the cache
+  if (event.persisted) {
+    document.querySelector('body').click();
+  }
+});

--- a/src/js/footer/index.js
+++ b/src/js/footer/index.js
@@ -5,3 +5,4 @@ import "./footerComponent/index.js";
 import "./dynamicCtaLabels/index.js";
 import "./hide-deriv-go";
 import "./changeBannerPadding";
+import "./closeMobileMenu";


### PR DESCRIPTION
This function is needed to close the menu if the page was loaded using the browser back button (from cache)