### PR TITLE
update 'close mobile menu' function

### DIFF
--- a/src/js/footer/closeMobileMenu/index.js
+++ b/src/js/footer/closeMobileMenu/index.js
@@ -2,6 +2,10 @@
 window.addEventListener('pageshow', function (event) {
   // Checking if the page was loaded from the cache
   if (event.persisted) {
-    document.querySelector('body').click();
+    const mobileMenu = document.querySelector('.w-nav-overlay');
+  	if (mobileMenu) {
+      mobileMenu.style.display = 'none';
+   		document.querySelector('body').click();
+    }
   }
 });


### PR DESCRIPTION
This function is needed to close the menu if the page was loaded using the browser back button (from cache)