### PR TITLE
nuzhy/_/hub.deriv.com to euPopup internal domains

### DIFF
--- a/src/js/footer/euPopUp/index.js
+++ b/src/js/footer/euPopUp/index.js
@@ -41,6 +41,7 @@ if (
     "signup.deriv.com",
     "login.deriv.com",
     "api.deriv.com",
+    "hub.deriv.com",
   ];
 
   let pendingRedirect = "";


### PR DESCRIPTION
- added hub.deriv.com to allowed domains in euPopup