### PR TITLE
Potential fix for code scanning alert no. 19: Regular expression injection

### DIFF
--- a/.github/modify_sitemap_new.js
+++ b/.github/modify_sitemap_new.js
@@ -1,6 +1,7 @@
 const fs = require("fs");
 const yargs = require("yargs");
 const xml2js = require("xml2js");
+const _ = require("lodash");
 
 const argv = yargs
   .option("staging-sitemap", {
@@ -162,8 +163,9 @@ function filterExcludedUrls(sitemap, newDomain) {
 
   const excludedPatterns = ["/partners-help-centre-questions/"];
 
-  const locPattern = new RegExp(`https://${newDomain}\/[^\/]+\/locations`, "i");
-  const locDirectPattern = new RegExp(`https://${newDomain}\/locations\/`, "i");
+  const safeNewDomain = _.escapeRegExp(newDomain);
+  const locPattern = new RegExp(`https://${safeNewDomain}\/[^\/]+\/locations`, "i");
+  const locDirectPattern = new RegExp(`https://${safeNewDomain}\/locations\/`, "i");
 
   sitemap.urlset.url = sitemap.urlset.url.filter((urlObj) => {
     if (!urlObj.loc || urlObj.loc.length === 0) {
@@ -192,7 +194,7 @@ function filterExcludedUrls(sitemap, newDomain) {
     }
 
     // Check for EU URLs
-    if (new RegExp(`https://${newDomain}(\/[a-z-]{2,5})?\/eu(\/)?`).test(url)) {
+    if (new RegExp(`https://${safeNewDomain}(\/[a-z-]{2,5})?\/eu(\/)?`).test(url)) {
       return false;
     }
 

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
     "rollup-plugin-postcss": "^4.0.2",
     "rollup-plugin-terser": "^7.0.2",
     "vite": "^5.2.13"
+  },
+  "dependencies": {
+    "lodash": "^4.17.21"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/deriv-com/webflow-deriv-com-scripts/security/code-scanning/19](https://github.com/deriv-com/webflow-deriv-com-scripts/security/code-scanning/19)

To fix the issue, the `newDomain` input should be sanitized before being used in the regular expression. The best approach is to use a sanitization function like `_.escapeRegExp` from the lodash library, which escapes all special characters that have special meaning in regular expressions. This ensures that the user input cannot modify the behavior of the regular expression.

The changes should be made in the `.github/modify_sitemap_new.js` file:
1. Import the lodash library.
2. Sanitize the `newDomain` variable using `_.escapeRegExp` before constructing any regular expressions that use it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
