### PR TITLE
Potential fix for code scanning alert no. 8: Incomplete URL substring sanitization

### DIFF
--- a/src/js/footer/helper/index.js
+++ b/src/js/footer/helper/index.js
@@ -187,7 +187,8 @@ export const loginUrl = () => {
       featureFlag: "trigger_login_for_hub",
     });
     if (typeof window.isTHLogin === "boolean" && window.isTHLogin) {
-      if (window.location.href.includes("staging.deriv.com")) {
+      const urlHost = new URL(window.location.href).host;
+      if (urlHost === "staging.deriv.com") {
         appId = 53503;
         domainAppId = 53503;
       } else {


### PR DESCRIPTION
Potential fix for [https://github.com/deriv-com/webflow-deriv-com-scripts/security/code-scanning/8](https://github.com/deriv-com/webflow-deriv-com-scripts/security/code-scanning/8)

To fix the issue, we need to parse the URL and validate its host explicitly instead of using substring matching. The `URL` constructor in JavaScript can be used to parse the URL and extract its host. We can then compare the host against the expected value (`staging.deriv.com`) to ensure it matches exactly.

The changes will involve:
1. Replacing the `window.location.href.includes("staging.deriv.com")` check with a parsed URL host comparison.
2. Using the `URL` constructor to parse `window.location.href` and extract the `host` property.
3. Comparing the extracted host with the expected value (`staging.deriv.com`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
